### PR TITLE
add nonce to gateway transporter because it violates the following Co…

### DIFF
--- a/src/Parbad/src/Internal/DefaultGatewayTransporter.cs
+++ b/src/Parbad/src/Internal/DefaultGatewayTransporter.cs
@@ -2,10 +2,13 @@
 // Licensed under the GNU GENERAL PUBLIC License, Version 3.0. See License.txt in the project root for license information.
 
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 using System;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Parbad.Options;
 
 namespace Parbad.Internal
 {
@@ -33,9 +36,17 @@ namespace Parbad.Internal
         {
             if (Descriptor.Type == GatewayTransporterDescriptor.TransportType.Post)
             {
+                string nonce = null;
+                var parbadOptions = _httpContext.RequestServices.GetRequiredService<IOptions<ParbadOptions>>();
+
                 HttpResponseUtilities.AddNecessaryContents(_httpContext, "text/html");
 
-                var form = HtmlFormBuilder.CreateForm(Descriptor.Url, Descriptor.Form);
+                if (parbadOptions.Value.NonceFactory != null)
+                {
+                    nonce = parbadOptions.Value.NonceFactory(_httpContext);
+                }
+
+                var form = HtmlFormBuilder.CreateForm(Descriptor.Url, Descriptor.Form, nonce);
 
                 var buffer = Encoding.UTF8.GetBytes(form);
 

--- a/src/Parbad/src/Internal/HtmlFormBuilder.cs
+++ b/src/Parbad/src/Internal/HtmlFormBuilder.cs
@@ -8,7 +8,7 @@ namespace Parbad.Internal
 {
     internal static class HtmlFormBuilder
     {
-        public static string CreateForm(string url, IEnumerable<KeyValuePair<string, string>> data)
+        public static string CreateForm(string url, IEnumerable<KeyValuePair<string, string>> data, string nonce = null)
         {
             var fields = string.Join("", data.Select(CreateHiddenInput));
 
@@ -18,7 +18,7 @@ namespace Parbad.Internal
                 $"<form id=\"paymentForm\" action=\"{url}\" method=\"post\" />" +
                 fields +
                 "</form>" +
-                "<script type=\"text/javascript\">" +
+                $"<script type=\"text/javascript\" {(string.IsNullOrWhiteSpace(nonce) ? null : $"nonce=\"{nonce}\"")}>" +
                 "document.getElementById('paymentForm').submit();" +
                 "</script>" +
                 "</body>" +

--- a/src/Parbad/src/Options/ParbadOptions.cs
+++ b/src/Parbad/src/Options/ParbadOptions.cs
@@ -1,4 +1,7 @@
-﻿namespace Parbad.Options
+﻿using Microsoft.AspNetCore.Http;
+using System;
+
+namespace Parbad.Options
 {
     /// <summary>
     /// Provides configuration for Parbad.
@@ -14,5 +17,10 @@
         /// Contains all messages that Parbad uses in results.
         /// </summary>
         public MessagesOptions Messages { get; set; } = new MessagesOptions();
+
+        /// <summary>
+        /// A delegate that allows for the generation of a nonce (a unique token) based on the HttpContext.
+        /// </summary>
+        public Func<HttpContext, string> NonceFactory { get; set; }
     }
 }


### PR DESCRIPTION
سلام وقت بخیر
به علت وجود هدر CSP امکان اجرای این اسکریپت وجود نداره:

```
<form id="paymentForm" action="https://localhost:7223/virtual" method="post"><input type="hidden" name="CommandType" value="request"><input type="hidden" name="trackingNumber" value="1001"><input type="hidden" name="amount" value="50000"><input type="hidden" name="redirectUrl" value="https://localhost:7223/Payment/Verify?paymentToken=724f1700531443cc880e821a653c596e"></form>
<script type="text/javascript">document.getElementById('paymentForm').submit();</script>
```

راه حل اضافه کردن nonce به script های مجاز که این nonce برای هر درخواست باید با هدر هماهنگ باشه. تغغیرات لازم برای دریافت nonce انجام شده. لطفا بررسی بفرمایید تا این مشکل هم برطرف بشه.