### PR TITLE
Add .NET 10 support and update package references

### DIFF
--- a/Parbad.sln
+++ b/Parbad.sln
@@ -107,6 +107,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Parbad.Gateway.IranKish", "
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Parbad.Gateway.IranKish.Tests", "src\Parbad.Gateway\IranKish\tests\Parbad.Gateway.IranKish.Tests.csproj", "{8A1C135B-12A5-42AB-A2F2-2660146ACB0C}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Parbad.FrameworkCompatibility.Tests", "tests\Parbad.FrameworkCompatibility.Tests\Parbad.FrameworkCompatibility.Tests.csproj", "{60BF4F46-AB43-4164-B55F-229F6FCCE0DC}"
+EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		src\Parbad.Shared\Parbad.Shared.projitems*{2e124fc2-6fa6-45e1-9912-edca1c19cef7}*SharedItemsImports = 13
@@ -210,6 +212,10 @@ Global
 		{8A1C135B-12A5-42AB-A2F2-2660146ACB0C}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{8A1C135B-12A5-42AB-A2F2-2660146ACB0C}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{8A1C135B-12A5-42AB-A2F2-2660146ACB0C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{60BF4F46-AB43-4164-B55F-229F6FCCE0DC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{60BF4F46-AB43-4164-B55F-229F6FCCE0DC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{60BF4F46-AB43-4164-B55F-229F6FCCE0DC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{60BF4F46-AB43-4164-B55F-229F6FCCE0DC}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -258,6 +264,7 @@ Global
 		{9D40B01A-7B71-40F8-8AEC-91C63438DFA0} = {B1447D20-66E0-46FB-B0DB-BCBEBA7B337A}
 		{9252FE79-9908-46C3-AAF2-C5F7426EDF84} = {9D40B01A-7B71-40F8-8AEC-91C63438DFA0}
 		{8A1C135B-12A5-42AB-A2F2-2660146ACB0C} = {9D40B01A-7B71-40F8-8AEC-91C63438DFA0}
+		{60BF4F46-AB43-4164-B55F-229F6FCCE0DC} = {6BB6AFB4-7951-4435-8C10-95AF86B200F8}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {CBDDB699-C14A-4235-B0AE-32725230B4ED}

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -11,16 +11,70 @@ pool:
 variables:
   buildConfiguration: 'release'
   projects: 'src/**/*.csproj'
+  dotnetRoot: '$(Agent.ToolsDirectory)/dotnet'
 
 steps:
 - task: UseDotNet@2
-  displayName: 'Use Dotnet'
+  displayName: 'Use .NET Core 3.0 SDK'
+  inputs:
+    packageType: 'sdk'
+    version: '3.0.x'
+    installationPath: '$(dotnetRoot)'
+
+- task: UseDotNet@2
+  displayName: 'Use .NET Core 3.1 SDK'
+  inputs:
+    packageType: 'sdk'
+    version: '3.1.x'
+    installationPath: '$(dotnetRoot)'
+
+- task: UseDotNet@2
+  displayName: 'Use .NET 5 SDK'
+  inputs:
+    packageType: 'sdk'
+    version: '5.0.x'
+    installationPath: '$(dotnetRoot)'
+
+- task: UseDotNet@2
+  displayName: 'Use .NET 6 SDK'
+  inputs:
+    packageType: 'sdk'
+    version: '6.0.x'
+    installationPath: '$(dotnetRoot)'
+
+- task: UseDotNet@2
+  displayName: 'Use .NET 7 SDK'
+  inputs:
+    packageType: 'sdk'
+    version: '7.0.x'
+    installationPath: '$(dotnetRoot)'
+
+- task: UseDotNet@2
+  displayName: 'Use .NET 8 SDK'
+  inputs:
+    packageType: 'sdk'
+    version: '8.0.x'
+    installationPath: '$(dotnetRoot)'
+
+- task: UseDotNet@2
+  displayName: 'Use .NET 9 SDK'
+  inputs:
+    packageType: 'sdk'
+    version: '9.0.x'
+    installationPath: '$(dotnetRoot)'
+
+- task: UseDotNet@2
+  displayName: 'Use .NET 10 SDK'
   inputs:
     packageType: 'sdk'
     version: '10.0.x'
+    installationPath: '$(dotnetRoot)'
 
-- script: dotnet --info
-  displayName: 'Show .NET SDK info'
+- script: |
+    dotnet --info
+    dotnet --list-sdks
+    dotnet --list-runtimes
+  displayName: 'Show .NET SDKs and runtimes'
 
 - task: DotNetCoreCLI@2
   displayName: 'restoring'
@@ -41,7 +95,7 @@ steps:
   inputs:
     command: 'test'
     projects: '**/*.Tests.csproj'
-    arguments: '-c $(buildConfiguration) --no-restore'
+    arguments: '-c $(buildConfiguration) --no-restore --verbosity normal'
 
 - task: DotNetCoreCLI@2
   displayName: 'packing'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -22,7 +22,7 @@ steps:
   displayName: Use Dotnet
   inputs:
     packageType: sdk
-    version: 9.x
+    version: 10.x
 - task: NuGetCommand@2
   displayName: 'restoring'
   inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -13,49 +13,54 @@ variables:
   projects: 'src/**/*.csproj'
 
 steps:
-- task: NuGetToolInstaller@1
-  displayName: 'Use Nuget'
-  inputs:
-    versionSpec: 
-    checkLatest: true
 - task: UseDotNet@2
-  displayName: Use Dotnet
+  displayName: 'Use Dotnet'
   inputs:
-    packageType: sdk
-    version: 10.x
-- task: NuGetCommand@2
+    packageType: 'sdk'
+    version: '10.0.x'
+
+- script: dotnet --info
+  displayName: 'Show .NET SDK info'
+
+- task: DotNetCoreCLI@2
   displayName: 'restoring'
   inputs:
     command: 'restore'
-    restoreSolution: '**/*.sln'
+    projects: '**/*.sln'
     feedsToUse: 'select'
+
 - task: DotNetCoreCLI@2
   displayName: 'building'
   inputs:
     command: 'build'
-    projects: $(projects)
-    arguments: '-c $(buildConfiguration)'
+    projects: '$(projects)'
+    arguments: '-c $(buildConfiguration) --no-restore'
+
 - task: DotNetCoreCLI@2
   displayName: 'testing'
   inputs:
     command: 'test'
     projects: '**/*.Tests.csproj'
+    arguments: '-c $(buildConfiguration) --no-restore'
+
 - task: DotNetCoreCLI@2
   displayName: 'packing'
   condition: eq(variables['build.sourceBranch'], 'refs/heads/dev')
   inputs:
     command: 'custom'
-    projects: $(projects)
+    projects: '$(projects)'
     custom: 'pack'
     arguments: '-c $(buildConfiguration) --no-build -o $(Build.ArtifactStagingDirectory) --version-suffix dev$(Build.BuildNumber)'
+
 - task: DotNetCoreCLI@2
   displayName: 'packing'
   condition: eq(variables['build.sourceBranch'], 'refs/heads/master')
   inputs:
     command: 'custom'
-    projects: $(projects)
+    projects: '$(projects)'
     custom: 'pack'
     arguments: '-c $(buildConfiguration) --no-build -o $(Build.ArtifactStagingDirectory)'
+
 - task: PublishBuildArtifacts@1
   inputs:
     PathtoPublish: '$(Build.ArtifactStagingDirectory)'

--- a/src/Parbad.AspNetCore/src/Parbad.AspNetCore.csproj
+++ b/src/Parbad.AspNetCore/src/Parbad.AspNetCore.csproj
@@ -4,7 +4,7 @@
     <PackageId>Parbad.AspNetCore</PackageId>
     <Product>Parbad.AspNetCore</Product>
     <VersionPrefix>1.5.0</VersionPrefix>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;netcoreapp3.0;netcoreapp3.1;net5.0;net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;netcoreapp3.0;netcoreapp3.1;net5.0;net6.0;net7.0;net8.0;net9.0;net10.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <Authors>Sina Soltani</Authors>
     <Copyright>Copyright © Sina Soltani 2016</Copyright>
@@ -36,9 +36,10 @@ For more information see: https://www.nuget.org/packages/Parbad/</Description>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' or '$(TargetFramework)' == 'netstandard2.1' ">
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.2.0" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="4.7.1" />
   </ItemGroup>
   
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.0' or '$(TargetFramework)' == 'netcoreapp3.1' or '$(TargetFramework)' == 'net5.0' or '$(TargetFramework)' == 'net6.0' or '$(TargetFramework)' == 'net7.0' or '$(TargetFramework)' == 'net8.0' or '$(TargetFramework)' == 'net9.0' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.0' or '$(TargetFramework)' == 'netcoreapp3.1' or '$(TargetFramework)' == 'net5.0' or '$(TargetFramework)' == 'net6.0' or '$(TargetFramework)' == 'net7.0' or '$(TargetFramework)' == 'net8.0' or '$(TargetFramework)' == 'net9.0' or '$(TargetFramework)' == 'net10.0' ">
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 

--- a/src/Parbad.AspNetCore/src/Parbad.AspNetCore.csproj
+++ b/src/Parbad.AspNetCore/src/Parbad.AspNetCore.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <PackageId>Parbad.AspNetCore</PackageId>
     <Product>Parbad.AspNetCore</Product>
-    <VersionPrefix>1.5.0</VersionPrefix>
+    <VersionPrefix>1.6.0</VersionPrefix>
     <TargetFrameworks>netstandard2.0;netstandard2.1;netcoreapp3.0;netcoreapp3.1;net5.0;net6.0;net7.0;net8.0;net9.0;net10.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <Authors>Sina Soltani</Authors>
@@ -20,7 +20,7 @@ For more information see: https://www.nuget.org/packages/Parbad/</Description>
     <PackageTags>parbad aspnetcore Payment Gateway Bank Iran Shetab IranKish Mellat Melli Sadad Parsian Pasargad Saman Asan-Pardakht پرداخت درگاه بانک ایران شتاب ایران-کیش ملت ملی سداد پارسیان پاسارگاد سامان آسان-پرداخت</PackageTags>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageLicenseExpression>LGPL-3.0-or-later</PackageLicenseExpression>
-    <PackageReleaseNotes>https://github.com/Sina-Soltani/Parbad/releases/tag/v3.10.0</PackageReleaseNotes>
+    <PackageReleaseNotes>https://github.com/Sina-Soltani/Parbad/releases/tag/v3.12.0</PackageReleaseNotes>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Parbad.AspNetCore/src/VirtualGateway/ParbadVirtualGatewayMiddlewareExtensions.cs
+++ b/src/Parbad.AspNetCore/src/VirtualGateway/ParbadVirtualGatewayMiddlewareExtensions.cs
@@ -21,9 +21,9 @@ public static class ParbadVirtualGatewayMiddlewareExtensions
     {
         if (builder == null) throw new ArgumentNullException(nameof(builder));
 
-#if NETCOREAPP3_0 || Net_5 || Net_6 || Net_7 || Net_8
-            var hostEnvironment = builder.ApplicationServices.GetRequiredService<Hosting.IWebHostEnvironment>();
-            var isDevelopment = Microsoft.Extensions.Hosting.HostEnvironmentEnvExtensions.IsDevelopment(hostEnvironment);
+#if NETCOREAPP3_0 || NETCOREAPP3_1 || NET5_0_OR_GREATER
+        var hostEnvironment = builder.ApplicationServices.GetRequiredService<Hosting.IWebHostEnvironment>();
+        var isDevelopment = Microsoft.Extensions.Hosting.HostEnvironmentEnvExtensions.IsDevelopment(hostEnvironment);
 #else
         var hostEnvironment = builder.ApplicationServices.GetRequiredService<Hosting.IHostingEnvironment>();
         var isDevelopment = Hosting.HostingEnvironmentExtensions.IsDevelopment(hostEnvironment);

--- a/src/Parbad.Gateway/FanAva/src/Parbad.Gateway.FanAva.csproj
+++ b/src/Parbad.Gateway/FanAva/src/Parbad.Gateway.FanAva.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <PackageId>Parbad.Gateway.FanAva</PackageId>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;netcoreapp3.0;net5.0;net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;netcoreapp3.0;net5.0;net6.0;net7.0;net8.0;net9.0;net10.0</TargetFrameworks>
     <VersionPrefix>1.4.0</VersionPrefix>
     <LangVersion>latest</LangVersion>
     <Authors>Mohammad Mokhtari</Authors>

--- a/src/Parbad.Gateway/FanAva/src/Parbad.Gateway.FanAva.csproj
+++ b/src/Parbad.Gateway/FanAva/src/Parbad.Gateway.FanAva.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <PackageId>Parbad.Gateway.FanAva</PackageId>
     <TargetFrameworks>netstandard2.0;netstandard2.1;netcoreapp3.0;net5.0;net6.0;net7.0;net8.0;net9.0;net10.0</TargetFrameworks>
-    <VersionPrefix>1.4.0</VersionPrefix>
+    <VersionPrefix>1.5.0</VersionPrefix>
     <LangVersion>latest</LangVersion>
     <Authors>Mohammad Mokhtari</Authors>
     <Copyright>Copyright © Sina Soltani 2016</Copyright>
@@ -15,7 +15,7 @@
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <PackageTags>parbad Payment Gateway FanAva پرداخت درگاه بانک فن آوا</PackageTags>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <PackageReleaseNotes>https://github.com/Sina-Soltani/Parbad/releases/tag/v3.11.0</PackageReleaseNotes>
+    <PackageReleaseNotes>https://github.com/Sina-Soltani/Parbad/releases/tag/v3.12.0</PackageReleaseNotes>
     <Description>FanAva Gateway for Parbad project.
 For more information see: https://www.nuget.org/packages/Parbad/</Description>
   </PropertyGroup>

--- a/src/Parbad.Gateway/FanAva/tests/Parbad.Gateway.FanAva.Tests.csproj
+++ b/src/Parbad.Gateway/FanAva/tests/Parbad.Gateway.FanAva.Tests.csproj
@@ -1,10 +1,20 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+    <PackageReference Include="MSTest.TestAdapter" Version="4.2.3" />
+    <PackageReference Include="MSTest.TestFramework" Version="4.2.3" />
+    <PackageReference Include="coverlet.collector" Version="10.0.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\..\..\tests\Parbad.Tests.Helpers\Parbad.Tests.Helpers.csproj" />

--- a/src/Parbad.Gateway/IdPay/src/Parbad.Gateway.IdPay.csproj
+++ b/src/Parbad.Gateway/IdPay/src/Parbad.Gateway.IdPay.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;netcoreapp3.0;net5.0;net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;netcoreapp3.0;net5.0;net6.0;net7.0;net8.0;net9.0;net10.0</TargetFrameworks>
     <VersionPrefix>1.6.0</VersionPrefix>
     <LangVersion>latest</LangVersion>
     <Authors>Sina Soltani</Authors>

--- a/src/Parbad.Gateway/IdPay/src/Parbad.Gateway.IdPay.csproj
+++ b/src/Parbad.Gateway/IdPay/src/Parbad.Gateway.IdPay.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;netstandard2.1;netcoreapp3.0;net5.0;net6.0;net7.0;net8.0;net9.0;net10.0</TargetFrameworks>
-    <VersionPrefix>1.6.0</VersionPrefix>
+    <VersionPrefix>1.7.0</VersionPrefix>
     <LangVersion>latest</LangVersion>
     <Authors>Sina Soltani</Authors>
     <Copyright>Copyright © Sina Soltani 2016</Copyright>
@@ -14,7 +14,7 @@
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <PackageTags>parbad Payment Gateway Bank Iran Shetab idpay پرداخت درگاه بانک ایران شتاب</PackageTags>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <PackageReleaseNotes>https://github.com/Sina-Soltani/Parbad/releases/tag/v3.11.0</PackageReleaseNotes>
+    <PackageReleaseNotes>https://github.com/Sina-Soltani/Parbad/releases/tag/v3.12.0</PackageReleaseNotes>
     <Description>IDPay.ir Gateway for Parbad project.
 
 For more information see: https://www.nuget.org/packages/Parbad/</Description>

--- a/src/Parbad.Gateway/IdPay/tests/Parbad.Gateway.IdPay.Tests.csproj
+++ b/src/Parbad.Gateway/IdPay/tests/Parbad.Gateway.IdPay.Tests.csproj
@@ -1,10 +1,20 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+    <PackageReference Include="MSTest.TestAdapter" Version="4.2.3" />
+    <PackageReference Include="MSTest.TestFramework" Version="4.2.3" />
+    <PackageReference Include="coverlet.collector" Version="10.0.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\..\..\tests\Parbad.Tests.Helpers\Parbad.Tests.Helpers.csproj" />

--- a/src/Parbad.Gateway/IranKish/src/Parbad.Gateway.IranKish.csproj
+++ b/src/Parbad.Gateway/IranKish/src/Parbad.Gateway.IranKish.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
     <PackageId>Parbad.Gateway.IranKish</PackageId>
     <Product>Parbad.Gateway.IranKish</Product>
-    <VersionPrefix>1.3.0</VersionPrefix>
+    <VersionPrefix>1.4.0</VersionPrefix>
     <TargetFrameworks>netstandard2.0;netstandard2.1;netcoreapp3.0;net5.0;net6.0;net7.0;net8.0;net9.0;net10.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <Authors>Sina Soltani</Authors>
@@ -16,7 +16,7 @@
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <PackageTags>parbad Payment gateway bank Iran shetab irankish پرداخت درگاه بانک ایران کیش</PackageTags>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <PackageReleaseNotes>https://github.com/Sina-Soltani/Parbad/releases/tag/v3.11.0</PackageReleaseNotes>
+    <PackageReleaseNotes>https://github.com/Sina-Soltani/Parbad/releases/tag/v3.12.0</PackageReleaseNotes>
         <Description>IranKish Gateway for Parbad project.
 
 For more information see: https://www.nuget.org/packages/Parbad/</Description>

--- a/src/Parbad.Gateway/IranKish/src/Parbad.Gateway.IranKish.csproj
+++ b/src/Parbad.Gateway/IranKish/src/Parbad.Gateway.IranKish.csproj
@@ -4,7 +4,7 @@
     <PackageId>Parbad.Gateway.IranKish</PackageId>
     <Product>Parbad.Gateway.IranKish</Product>
     <VersionPrefix>1.3.0</VersionPrefix>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;netcoreapp3.0;net5.0;net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;netcoreapp3.0;net5.0;net6.0;net7.0;net8.0;net9.0;net10.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <Authors>Sina Soltani</Authors>
     <Copyright>Copyright © Sina Soltani 2016</Copyright>

--- a/src/Parbad.Gateway/IranKish/tests/Parbad.Gateway.IranKish.Tests.csproj
+++ b/src/Parbad.Gateway/IranKish/tests/Parbad.Gateway.IranKish.Tests.csproj
@@ -1,12 +1,22 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net9.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <LangVersion>latest</LangVersion>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <IsPackable>false</IsPackable>
     </PropertyGroup>
+
+    <ItemGroup>
+      <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+      <PackageReference Include="MSTest.TestAdapter" Version="4.2.3" />
+      <PackageReference Include="MSTest.TestFramework" Version="4.2.3" />
+      <PackageReference Include="coverlet.collector" Version="10.0.1">
+        <PrivateAssets>all</PrivateAssets>
+        <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      </PackageReference>
+    </ItemGroup>
 
     <ItemGroup>
       <ProjectReference Include="..\..\..\..\tests\Parbad.Tests.Helpers\Parbad.Tests.Helpers.csproj" />

--- a/src/Parbad.Gateway/PayIr/src/Parbad.Gateway.PayIr.csproj
+++ b/src/Parbad.Gateway/PayIr/src/Parbad.Gateway.PayIr.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <PackageId>Parbad.Gateway.PayIr</PackageId>
     <Product>Parbad.Gateway.PayIr</Product>
-    <VersionPrefix>1.8.0</VersionPrefix>
+    <VersionPrefix>1.9.0</VersionPrefix>
     <TargetFrameworks>netstandard2.0;netstandard2.1;netcoreapp3.0;net5.0;net6.0;net7.0;net8.0;net9.0;net10.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <Authors>Sina Soltani</Authors>
@@ -16,7 +16,7 @@
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <PackageTags>parbad Payment Gateway Bank Iran Shetab pay.ir پرداخت درگاه بانک ایران شتاب پی</PackageTags>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <PackageReleaseNotes>https://github.com/Sina-Soltani/Parbad/releases/tag/v3.11.0</PackageReleaseNotes>
+    <PackageReleaseNotes>https://github.com/Sina-Soltani/Parbad/releases/tag/v3.12.0</PackageReleaseNotes>
     <Description>Pay.ir Gateway for Parbad project.
 
 For more information see: https://www.nuget.org/packages/Parbad/</Description>

--- a/src/Parbad.Gateway/PayIr/src/Parbad.Gateway.PayIr.csproj
+++ b/src/Parbad.Gateway/PayIr/src/Parbad.Gateway.PayIr.csproj
@@ -4,7 +4,7 @@
     <PackageId>Parbad.Gateway.PayIr</PackageId>
     <Product>Parbad.Gateway.PayIr</Product>
     <VersionPrefix>1.8.0</VersionPrefix>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;netcoreapp3.0;net5.0;net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;netcoreapp3.0;net5.0;net6.0;net7.0;net8.0;net9.0;net10.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <Authors>Sina Soltani</Authors>
     <Copyright>Copyright © Sina Soltani 2016</Copyright>

--- a/src/Parbad.Gateway/PayPing/src/Parbad.Gateway.PayPing.csproj
+++ b/src/Parbad.Gateway/PayPing/src/Parbad.Gateway.PayPing.csproj
@@ -3,7 +3,7 @@
     <PackageId>Parbad.Gateway.PayPing</PackageId>
     <Product>Parbad.Gateway.PayPing</Product>
     <VersionPrefix>1.5.0</VersionPrefix>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;netcoreapp3.0;net5.0;net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;netcoreapp3.0;net5.0;net6.0;net7.0;net8.0;net9.0;net10.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <Authors>Ali Zaferany</Authors>
     <Copyright>Copyright © Parbad 2016</Copyright>

--- a/src/Parbad.Gateway/PayPing/src/Parbad.Gateway.PayPing.csproj
+++ b/src/Parbad.Gateway/PayPing/src/Parbad.Gateway.PayPing.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <PackageId>Parbad.Gateway.PayPing</PackageId>
     <Product>Parbad.Gateway.PayPing</Product>
-    <VersionPrefix>1.5.0</VersionPrefix>
+    <VersionPrefix>1.6.0</VersionPrefix>
     <TargetFrameworks>netstandard2.0;netstandard2.1;netcoreapp3.0;net5.0;net6.0;net7.0;net8.0;net9.0;net10.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <Authors>Ali Zaferany</Authors>
@@ -16,7 +16,7 @@
     <PackageLicenseExpression>LGPL-3.0-or-later</PackageLicenseExpression>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <PackageReleaseNotes>https://github.com/Sina-Soltani/Parbad/releases/tag/v3.11.0</PackageReleaseNotes>
+    <PackageReleaseNotes>https://github.com/Sina-Soltani/Parbad/releases/tag/v3.12.0</PackageReleaseNotes>
     <Description>PayPing Gateway for Parbad project.
 For more information see: https://github.com/Sina-Soltani/Parbad</Description>
   </PropertyGroup>

--- a/src/Parbad.Gateway/Sepehr/src/Parbad.Gateway.Sepehr.csproj
+++ b/src/Parbad.Gateway/Sepehr/src/Parbad.Gateway.Sepehr.csproj
@@ -4,7 +4,7 @@
     <PackageId>Parbad.Gateway.Sepehr</PackageId>
     <Product>Parbad.Gateway.Sepehr</Product>
     <VersionPrefix>1.7.0</VersionPrefix>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;netcoreapp3.0;net5.0;net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;netcoreapp3.0;net5.0;net6.0;net7.0;net8.0;net9.0;net10.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <Authors>Sina Soltani</Authors>
     <Copyright>Copyright © Sina Soltani 2016</Copyright>

--- a/src/Parbad.Gateway/Sepehr/src/Parbad.Gateway.Sepehr.csproj
+++ b/src/Parbad.Gateway/Sepehr/src/Parbad.Gateway.Sepehr.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <PackageId>Parbad.Gateway.Sepehr</PackageId>
     <Product>Parbad.Gateway.Sepehr</Product>
-    <VersionPrefix>1.7.0</VersionPrefix>
+    <VersionPrefix>1.8.0</VersionPrefix>
     <TargetFrameworks>netstandard2.0;netstandard2.1;netcoreapp3.0;net5.0;net6.0;net7.0;net8.0;net9.0;net10.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <Authors>Sina Soltani</Authors>
@@ -16,7 +16,7 @@
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <PackageTags>parbad Payment gateway bank Iran shetab sepehr mabna پرداخت درگاه بانک ایران شتاب سپهر مبنا کارت</PackageTags>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <PackageReleaseNotes>https://github.com/Sina-Soltani/Parbad/releases/tag/v3.11.0</PackageReleaseNotes>
+    <PackageReleaseNotes>https://github.com/Sina-Soltani/Parbad/releases/tag/v3.12.0</PackageReleaseNotes>
     <Description>Sepehr Gateway for Parbad project.
 
 For more information see: https://www.nuget.org/packages/Parbad/</Description>

--- a/src/Parbad.Gateway/YekPay/src/Parbad.Gateway.YekPay.csproj
+++ b/src/Parbad.Gateway/YekPay/src/Parbad.Gateway.YekPay.csproj
@@ -4,7 +4,7 @@
     <PackageId>Parbad.Gateway.YekPay</PackageId>
     <Product>Parbad.Gateway.YekPay</Product>
     <VersionPrefix>1.6.0</VersionPrefix>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;netcoreapp3.0;net5.0;net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;netcoreapp3.0;net5.0;net6.0;net7.0;net8.0;net9.0;net10.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <Authors>Sina Soltani</Authors>
     <Copyright>Copyright © Sina Soltani 2016</Copyright>

--- a/src/Parbad.Gateway/YekPay/src/Parbad.Gateway.YekPay.csproj
+++ b/src/Parbad.Gateway/YekPay/src/Parbad.Gateway.YekPay.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <PackageId>Parbad.Gateway.YekPay</PackageId>
     <Product>Parbad.Gateway.YekPay</Product>
-    <VersionPrefix>1.6.0</VersionPrefix>
+    <VersionPrefix>1.7.0</VersionPrefix>
     <TargetFrameworks>netstandard2.0;netstandard2.1;netcoreapp3.0;net5.0;net6.0;net7.0;net8.0;net9.0;net10.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <Authors>Sina Soltani</Authors>
@@ -16,7 +16,7 @@
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <PackageTags>parbad Payment gateway bank Iran shetab yekpay  پرداخت درگاه بانک ایران شتاب یک پی</PackageTags>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <PackageReleaseNotes>https://github.com/Sina-Soltani/Parbad/releases/tag/v3.11.0</PackageReleaseNotes>
+    <PackageReleaseNotes>https://github.com/Sina-Soltani/Parbad/releases/tag/v3.12.0</PackageReleaseNotes>
     <Description>YekPay Gateway for Parbad project.
 
 For more information see: https://www.nuget.org/packages/Parbad/</Description>

--- a/src/Parbad.Gateway/ZarinPal/src/Parbad.Gateway.ZarinPal.csproj
+++ b/src/Parbad.Gateway/ZarinPal/src/Parbad.Gateway.ZarinPal.csproj
@@ -4,7 +4,7 @@
     <PackageId>Parbad.Gateway.ZarinPal</PackageId>
     <Product>Parbad.Gateway.ZarinPal</Product>
     <VersionPrefix>1.7.1</VersionPrefix>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;netcoreapp3.0;net5.0;net6.0;net6.0;net7.0;net8;net9.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;netcoreapp3.0;net5.0;net6.0;net6.0;net7.0;net8;net9.0;net10.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <Authors>Sina Soltani</Authors>
     <Copyright>Copyright © Sina Soltani 2016</Copyright>

--- a/src/Parbad.Gateway/ZarinPal/src/Parbad.Gateway.ZarinPal.csproj
+++ b/src/Parbad.Gateway/ZarinPal/src/Parbad.Gateway.ZarinPal.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <PackageId>Parbad.Gateway.ZarinPal</PackageId>
     <Product>Parbad.Gateway.ZarinPal</Product>
-    <VersionPrefix>1.7.1</VersionPrefix>
+    <VersionPrefix>1.8.0</VersionPrefix>
     <TargetFrameworks>netstandard2.0;netstandard2.1;netcoreapp3.0;net5.0;net6.0;net6.0;net7.0;net8;net9.0;net10.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <Authors>Sina Soltani</Authors>
@@ -19,7 +19,7 @@
     <Description>ZarinPal Gateway for Parbad project.
 
 For more information see: https://github.com/Sina-Soltani/Parbad</Description>
-    <PackageReleaseNotes>https://github.com/Sina-Soltani/Parbad/releases/tag/v3.11.0</PackageReleaseNotes>
+    <PackageReleaseNotes>https://github.com/Sina-Soltani/Parbad/releases/tag/v3.12.0</PackageReleaseNotes>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Parbad.Gateway/Zibal/src/Parbad.Gateway.Zibal.csproj
+++ b/src/Parbad.Gateway/Zibal/src/Parbad.Gateway.Zibal.csproj
@@ -5,7 +5,7 @@
     <Product>Parbad.Gateway.Zibal</Product>
 	<Nullable>enable</Nullable>
     <VersionPrefix>1.4.0</VersionPrefix>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;netcoreapp3.0;net5.0;net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;netcoreapp3.0;net5.0;net6.0;net7.0;net8.0;net9.0;net10.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <Authors>Mohammad Ashrafi</Authors>
     <Copyright>Copyright © Sina Soltani 2016</Copyright>

--- a/src/Parbad.Gateway/Zibal/src/Parbad.Gateway.Zibal.csproj
+++ b/src/Parbad.Gateway/Zibal/src/Parbad.Gateway.Zibal.csproj
@@ -4,7 +4,7 @@
     <PackageId>Parbad.Gateway.Zibal</PackageId>
     <Product>Parbad.Gateway.Zibal</Product>
 	<Nullable>enable</Nullable>
-    <VersionPrefix>1.4.0</VersionPrefix>
+    <VersionPrefix>1.5.0</VersionPrefix>
     <TargetFrameworks>netstandard2.0;netstandard2.1;netcoreapp3.0;net5.0;net6.0;net7.0;net8.0;net9.0;net10.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <Authors>Mohammad Ashrafi</Authors>
@@ -17,7 +17,7 @@
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <PackageTags>parbad Payment Gateway Bank Iran Shetab zibal پرداخت درگاه بانک ایران شتاب زیبال</PackageTags>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
-    <PackageReleaseNotes>https://github.com/Sina-Soltani/Parbad/releases/tag/v3.11.0</PackageReleaseNotes>
+    <PackageReleaseNotes>https://github.com/Sina-Soltani/Parbad/releases/tag/v3.12.0</PackageReleaseNotes>
     <Description>Zibal Gateway for Parbad project.
 
 For more information see: https://github.com/Sina-Soltani/Parbad</Description>

--- a/src/Parbad.Mvc/src/Parbad.Mvc.csproj
+++ b/src/Parbad.Mvc/src/Parbad.Mvc.csproj
@@ -35,7 +35,7 @@ For more information see: https://www.nuget.org/packages/Parbad/</Description>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNet.Mvc" Version="4.0.20505" />
+    <PackageReference Include="Microsoft.AspNet.Mvc" Version="5.3.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Parbad.Mvc/src/Parbad.Mvc.csproj
+++ b/src/Parbad.Mvc/src/Parbad.Mvc.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <PackageId>Parbad.Mvc5</PackageId>
     <Product>Parbad.Mvc5</Product>
-    <VersionPrefix>2.3.0</VersionPrefix>
+    <VersionPrefix>2.4.0</VersionPrefix>
     <TargetFramework>net462</TargetFramework>
     <LangVersion>9</LangVersion>
     <Authors>Sina Soltani</Authors>
@@ -20,7 +20,7 @@ For more information see: https://www.nuget.org/packages/Parbad/</Description>
     <PackageTags>parbad mvc Payment Gateway Bank Iran Shetab IranKish Mellat Melli Sadad Parsian Pasargad Saman Asan-Pardakht پرداخت درگاه بانک ایران شتاب ایران-کیش ملت ملی سداد پارسیان پاسارگاد سامان آسان-پرداخت</PackageTags>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageLicenseExpression>LGPL-3.0-or-later</PackageLicenseExpression>
-    <PackageReleaseNotes>https://github.com/Sina-Soltani/Parbad/releases/tag/v3.9.0</PackageReleaseNotes>
+    <PackageReleaseNotes>https://github.com/Sina-Soltani/Parbad/releases/tag/v3.12.0</PackageReleaseNotes>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Parbad.Owin/src/Parbad.Owin.csproj
+++ b/src/Parbad.Owin/src/Parbad.Owin.csproj
@@ -4,7 +4,7 @@
     <PackageId>Parbad.Owin</PackageId>
     <Product>Parbad.Owin</Product>
     <TargetFramework>net462</TargetFramework>
-    <VersionPrefix>1.3.0</VersionPrefix>
+    <VersionPrefix>1.4.0</VersionPrefix>
     <LangVersion>latest</LangVersion>
     <Authors>Sina Soltani</Authors>
     <Description>Owin integration for Parbad project.
@@ -20,7 +20,7 @@ For more information see: https://www.nuget.org/packages/Parbad/</Description>
     <PackageTags>parbad owin webforms Payment Gateway Bank Iran Shetab IranKish Mellat Melli Sadad Parsian Pasargad Saman Asan-Pardakht پرداخت درگاه بانک ایران شتاب ایران-کیش ملت ملی سداد پارسیان پاسارگاد سامان آسان-پرداخت</PackageTags>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageLicenseExpression>LGPL-3.0-or-later</PackageLicenseExpression>
-    <PackageReleaseNotes>https://github.com/Sina-Soltani/Parbad/releases/tag/v3.9.0</PackageReleaseNotes>
+    <PackageReleaseNotes>https://github.com/Sina-Soltani/Parbad/releases/tag/v3.12.0</PackageReleaseNotes>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Parbad.Owin/src/Parbad.Owin.csproj
+++ b/src/Parbad.Owin/src/Parbad.Owin.csproj
@@ -35,8 +35,8 @@ For more information see: https://www.nuget.org/packages/Parbad/</Description>
   </PropertyGroup>
     
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Owin" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Owin.Host.SystemWeb" Version="4.0.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Owin" Version="2.3.10" />
+    <PackageReference Include="Microsoft.Owin.Host.SystemWeb" Version="4.2.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Parbad.Storage/Abstractions/Parbad.Storage.Abstractions.csproj
+++ b/src/Parbad.Storage/Abstractions/Parbad.Storage.Abstractions.csproj
@@ -5,7 +5,7 @@
     <Product>Parbad.Storage.Abstractions</Product>
     <VersionPrefix>1.3.0</VersionPrefix>
     <LangVersion>latest</LangVersion>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;netcoreapp3.0;netcoreapp3.1;net5.0;net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;netcoreapp3.0;netcoreapp3.1;net5.0;net6.0;net7.0;net8.0;net9.0;net10.0</TargetFrameworks>
     <Nullable>enable</Nullable>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
@@ -38,7 +38,7 @@ More information: https://github.com/Sina-Soltani/Parbad</Description>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.2.0" />
   </ItemGroup>
     
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.0' or '$(TargetFramework)' == 'netcoreapp3.1' or '$(TargetFramework)' == 'net5.0' or '$(TargetFramework)' == 'net6.0' or '$(TargetFramework)' == 'net7.0' or '$(TargetFramework)' == 'net8.0' or '$(TargetFramework)' == 'net9.0' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.0' or '$(TargetFramework)' == 'netcoreapp3.1' or '$(TargetFramework)' == 'net5.0' or '$(TargetFramework)' == 'net6.0' or '$(TargetFramework)' == 'net7.0' or '$(TargetFramework)' == 'net8.0' or '$(TargetFramework)' == 'net9.0' or '$(TargetFramework)' == 'net10.0' ">
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 

--- a/src/Parbad.Storage/Abstractions/Parbad.Storage.Abstractions.csproj
+++ b/src/Parbad.Storage/Abstractions/Parbad.Storage.Abstractions.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <PackageId>Parbad.Storage.Abstractions</PackageId>
     <Product>Parbad.Storage.Abstractions</Product>
-    <VersionPrefix>1.3.0</VersionPrefix>
+    <VersionPrefix>1.4.0</VersionPrefix>
     <LangVersion>latest</LangVersion>
     <TargetFrameworks>netstandard2.0;netstandard2.1;netcoreapp3.0;netcoreapp3.1;net5.0;net6.0;net7.0;net8.0;net9.0;net10.0</TargetFrameworks>
     <Nullable>enable</Nullable>
@@ -20,7 +20,7 @@ More information: https://github.com/Sina-Soltani/Parbad</Description>
     <PackageTags>parbad storage</PackageTags>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Authors>Sina Soltani</Authors>
-    <PackageReleaseNotes>https://github.com/Sina-Soltani/Parbad/releases/tag/v3.10.0</PackageReleaseNotes>
+    <PackageReleaseNotes>https://github.com/Sina-Soltani/Parbad/releases/tag/v3.12.0</PackageReleaseNotes>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Parbad.Storage/Cache/src/Parbad.Storage.Cache.csproj
+++ b/src/Parbad.Storage/Cache/src/Parbad.Storage.Cache.csproj
@@ -4,7 +4,7 @@
     <PackageId>Parbad.Storage.Cache</PackageId>
     <VersionPrefix>1.5.0</VersionPrefix>
     <LangVersion>latest</LangVersion>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;netcoreapp3.0;netcoreapp3.1;net5.0;net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;netcoreapp3.0;netcoreapp3.1;net5.0;net6.0;net7.0;net8.0;net9.0;net10.0</TargetFrameworks>
     <Nullable>enable</Nullable>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
@@ -35,14 +35,14 @@ More information: https://github.com/Sina-Soltani/Parbad</Description>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
   </ItemGroup>
     
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' or '$(TargetFramework)' == 'netstandard2.1' ">
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="2.2.0" />
   </ItemGroup>
     
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.0' or '$(TargetFramework)' == 'netcoreapp3.1' or '$(TargetFramework)' == 'net5.0' or '$(TargetFramework)' == 'net6.0' or '$(TargetFramework)' == 'net7.0' or '$(TargetFramework)' == 'net8.0' or '$(TargetFramework)' == 'net9.0' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.0' or '$(TargetFramework)' == 'netcoreapp3.1' or '$(TargetFramework)' == 'net5.0' or '$(TargetFramework)' == 'net6.0' or '$(TargetFramework)' == 'net7.0' or '$(TargetFramework)' == 'net8.0' or '$(TargetFramework)' == 'net9.0' or '$(TargetFramework)' == 'net10.0' ">
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 

--- a/src/Parbad.Storage/Cache/src/Parbad.Storage.Cache.csproj
+++ b/src/Parbad.Storage/Cache/src/Parbad.Storage.Cache.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <PackageId>Parbad.Storage.Cache</PackageId>
-    <VersionPrefix>1.5.0</VersionPrefix>
+    <VersionPrefix>1.6.0</VersionPrefix>
     <LangVersion>latest</LangVersion>
     <TargetFrameworks>netstandard2.0;netstandard2.1;netcoreapp3.0;netcoreapp3.1;net5.0;net6.0;net7.0;net8.0;net9.0;net10.0</TargetFrameworks>
     <Nullable>enable</Nullable>
@@ -20,7 +20,7 @@ More information: https://github.com/Sina-Soltani/Parbad</Description>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Authors>Sina Soltani</Authors>
     <Product>Parbad.Storage.Cache</Product>
-    <PackageReleaseNotes>https://github.com/Sina-Soltani/Parbad/releases/tag/v3.10.0</PackageReleaseNotes>
+    <PackageReleaseNotes>https://github.com/Sina-Soltani/Parbad/releases/tag/v3.12.0</PackageReleaseNotes>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Parbad.Storage/Cache/tests/DistributedMemoryCacheTests.cs
+++ b/src/Parbad.Storage/Cache/tests/DistributedMemoryCacheTests.cs
@@ -52,9 +52,9 @@ public class DistributedMemoryCacheTests
     }
 
     [TestCleanup]
-    public ValueTask Cleanup()
+    public Task Cleanup()
     {
-        return _services.DisposeAsync();
+        return _services.DisposeAsync().AsTask();
     }
 
     [TestMethod]

--- a/src/Parbad.Storage/Cache/tests/MemoryCacheTests.cs
+++ b/src/Parbad.Storage/Cache/tests/MemoryCacheTests.cs
@@ -52,9 +52,9 @@ public class MemoryCacheTests
     }
 
     [TestCleanup]
-    public ValueTask Cleanup()
+    public Task Cleanup()
     {
-        return _services.DisposeAsync();
+        return _services.DisposeAsync().AsTask();
     }
 
     [TestMethod]

--- a/src/Parbad.Storage/Cache/tests/Parbad.Storage.Cache.Tests.csproj
+++ b/src/Parbad.Storage/Cache/tests/Parbad.Storage.Cache.Tests.csproj
@@ -1,16 +1,16 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
-    <PackageReference Include="coverlet.collector" Version="6.0.0">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+    <PackageReference Include="MSTest.TestAdapter" Version="4.2.3" />
+    <PackageReference Include="MSTest.TestFramework" Version="4.2.3" />
+    <PackageReference Include="coverlet.collector" Version="10.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/Parbad.Storage/EntityFrameworkCore/src/EntityFrameworkCoreStorage.cs
+++ b/src/Parbad.Storage/EntityFrameworkCore/src/EntityFrameworkCoreStorage.cs
@@ -65,6 +65,7 @@ public class EntityFrameworkCoreStorage : IStorage
 
         var record = await Context
                           .Payments
+                          .AsQueryable()
                           .AsNoTracking()
                           .SingleOrDefaultAsync(model => model.Id == payment.Id, cancellationToken);
 
@@ -85,6 +86,7 @@ public class EntityFrameworkCoreStorage : IStorage
 
         var record = await Context
                           .Payments
+                          .AsQueryable()
                           .AsNoTracking()
                           .SingleOrDefaultAsync(model => model.Id == payment.Id, cancellationToken);
 
@@ -117,6 +119,7 @@ public class EntityFrameworkCoreStorage : IStorage
 
         var record = await Context
                           .Transactions
+                          .AsQueryable()
                           .SingleOrDefaultAsync(model => model.Id == transaction.Id, cancellationToken);
 
         if (record == null) throw new InvalidOperationException($"No transaction records found in database with id {transaction.Id}");
@@ -136,6 +139,7 @@ public class EntityFrameworkCoreStorage : IStorage
 
         var record = await Context
                           .Transactions
+                          .AsQueryable()
                           .SingleOrDefaultAsync(model => model.Id == transaction.Id, cancellationToken);
 
         if (record == null) throw new InvalidOperationException($"No transaction records found in database with id {transaction.Id}");
@@ -149,6 +153,7 @@ public class EntityFrameworkCoreStorage : IStorage
     public virtual async Task<Payment?> GetPaymentByTrackingNumberAsync(long trackingNumber, CancellationToken cancellationToken = default)
     {
         var paymentEntity = await Context.Payments
+                                         .AsQueryable()
                                          .AsNoTracking()
                                          .SingleOrDefaultAsync(payment => payment.TrackingNumber == trackingNumber, cancellationToken);
 
@@ -159,6 +164,7 @@ public class EntityFrameworkCoreStorage : IStorage
     public virtual async Task<Payment?> GetPaymentByTokenAsync(string paymentToken, CancellationToken cancellationToken = default)
     {
         var paymentEntity = await Context.Payments
+                                         .AsQueryable()
                                          .AsNoTracking()
                                          .SingleOrDefaultAsync(payment => payment.Token == paymentToken, cancellationToken);
 
@@ -168,19 +174,24 @@ public class EntityFrameworkCoreStorage : IStorage
     /// <inheritdoc />
     public virtual Task<bool> DoesPaymentExistAsync(long trackingNumber, CancellationToken cancellationToken = default)
     {
-        return Context.Payments.AnyAsync(payment => payment.TrackingNumber == trackingNumber, cancellationToken);
+        return Context.Payments
+                      .AsQueryable()
+                      .AnyAsync(payment => payment.TrackingNumber == trackingNumber, cancellationToken);
     }
 
     /// <inheritdoc />
     public virtual Task<bool> DoesPaymentExistAsync(string paymentToken, CancellationToken cancellationToken = default)
     {
-        return Context.Payments.AnyAsync(payment => payment.Token == paymentToken, cancellationToken);
+        return Context.Payments
+                      .AsQueryable()
+                      .AnyAsync(payment => payment.Token == paymentToken, cancellationToken);
     }
 
     /// <inheritdoc />
     public virtual Task<List<Transaction>> GetTransactionsAsync(Payment payment, CancellationToken cancellationToken = default)
     {
         return Context.Transactions
+                      .AsQueryable()
                       .Where(transaction => transaction.PaymentId == payment.Id)
                       .AsNoTracking()
                       .Select(Mapper.ToTransactionModel())

--- a/src/Parbad.Storage/EntityFrameworkCore/src/Parbad.Storage.EntityFrameworkCore.csproj
+++ b/src/Parbad.Storage/EntityFrameworkCore/src/Parbad.Storage.EntityFrameworkCore.csproj
@@ -4,7 +4,7 @@
     <PackageId>Parbad.Storage.EntityFrameworkCore</PackageId>
     <VersionPrefix>1.6.0</VersionPrefix>
     <LangVersion>latest</LangVersion>
-    <TargetFrameworks>net5;net6;net7;net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>net5;net6;net7;net8.0;net9.0;net10.0</TargetFrameworks>
     <Nullable>enable</Nullable>  
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
@@ -44,8 +44,12 @@ More information: https://github.com/Sina-Soltani/Parbad</Description>
     <None Include="Parbad.Storage.EntityFrameworkCore.xml" pack="true" Visible="false" PackagePath="" />
   </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="5.0.0" />
+  <ItemGroup Condition=" '$(TargetFramework)' != 'net10.0' ">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="5.0.17" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net10.0' ">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.8" />
   </ItemGroup>
 
 </Project>

--- a/src/Parbad.Storage/EntityFrameworkCore/src/Parbad.Storage.EntityFrameworkCore.csproj
+++ b/src/Parbad.Storage/EntityFrameworkCore/src/Parbad.Storage.EntityFrameworkCore.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <PackageId>Parbad.Storage.EntityFrameworkCore</PackageId>
-    <VersionPrefix>1.6.0</VersionPrefix>
+    <VersionPrefix>1.7.0</VersionPrefix>
     <LangVersion>latest</LangVersion>
     <TargetFrameworks>net5;net6;net7;net8.0;net9.0;net10.0</TargetFrameworks>
     <Nullable>enable</Nullable>  
@@ -20,7 +20,7 @@ More information: https://github.com/Sina-Soltani/Parbad</Description>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Authors>Sina Soltani</Authors>
     <Product>Parbad.Storage.EntityframeworkCore</Product>
-    <PackageReleaseNotes>https://github.com/Sina-Soltani/Parbad/releases/tag/v3.10.0</PackageReleaseNotes>
+    <PackageReleaseNotes>https://github.com/Sina-Soltani/Parbad/releases/tag/v3.12.0</PackageReleaseNotes>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Parbad.Storage/EntityFrameworkCore/tests/EntityFrameworkCoreStorageTests.cs
+++ b/src/Parbad.Storage/EntityFrameworkCore/tests/EntityFrameworkCoreStorageTests.cs
@@ -54,9 +54,9 @@ namespace Parbad.Storage.EntityFrameworkCore.Tests
         }
 
         [TestCleanup]
-        public ValueTask Cleanup()
+        public Task Cleanup()
         {
-            return _context.DisposeAsync();
+            return _context.DisposeAsync().AsTask();
         }
 
         [TestMethod]

--- a/src/Parbad.Storage/EntityFrameworkCore/tests/Parbad.Storage.EntityFrameworkCore.Tests.csproj
+++ b/src/Parbad.Storage/EntityFrameworkCore/tests/Parbad.Storage.EntityFrameworkCore.Tests.csproj
@@ -1,18 +1,18 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CompareNETObjects" Version="4.73.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="3.1.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
-    <PackageReference Include="coverlet.collector" Version="3.2.0">
+    <PackageReference Include="CompareNETObjects" Version="4.84.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.8" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+    <PackageReference Include="MSTest.TestAdapter" Version="4.2.3" />
+    <PackageReference Include="MSTest.TestFramework" Version="4.2.3" />
+    <PackageReference Include="coverlet.collector" Version="10.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/Parbad/src/Parbad.csproj
+++ b/src/Parbad/src/Parbad.csproj
@@ -4,7 +4,7 @@
     <PackageId>Parbad</PackageId>
     <Product>Parbad</Product>
     <VersionPrefix>3.11.3</VersionPrefix>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;netcoreapp3.0;netcoreapp3.1;net5.0;net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;netcoreapp3.0;netcoreapp3.1;net5.0;net6.0;net7.0;net8.0;net9.0;net10.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <Authors>Parbad Sina Soltani</Authors>
     <Description>Parbad is a free, open-source, integrated and extensible library which connects your web applications to online payment gateways. Gateways can be added or developed by you.
@@ -38,16 +38,18 @@ More information: https://github.com/Sina-Soltani/Parbad
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' or '$(TargetFramework)' == 'netstandard2.1' ">
     <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="2.2.0" />
+    <PackageReference Include="System.Text.Encodings.Web" Version="4.7.2" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.0' or '$(TargetFramework)' == 'netcoreapp3.1' or '$(TargetFramework)' == 'net5.0' or '$(TargetFramework)' == 'net6.0' or '$(TargetFramework)' == 'net7.0' or '$(TargetFramework)' == 'net8.0' or '$(TargetFramework)' == 'net9.0' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.0' or '$(TargetFramework)' == 'netcoreapp3.1' or '$(TargetFramework)' == 'net5.0' or '$(TargetFramework)' == 'net6.0' or '$(TargetFramework)' == 'net7.0' or '$(TargetFramework)' == 'net8.0' or '$(TargetFramework)' == 'net9.0' or '$(TargetFramework)' == 'net10.0' ">
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 

--- a/src/Parbad/src/Parbad.csproj
+++ b/src/Parbad/src/Parbad.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <PackageId>Parbad</PackageId>
     <Product>Parbad</Product>
-    <VersionPrefix>3.11.3</VersionPrefix>
+    <VersionPrefix>3.12.0</VersionPrefix>
     <TargetFrameworks>netstandard2.0;netstandard2.1;netcoreapp3.0;netcoreapp3.1;net5.0;net6.0;net7.0;net8.0;net9.0;net10.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <Authors>Parbad Sina Soltani</Authors>
@@ -23,7 +23,7 @@ More information: https://github.com/Sina-Soltani/Parbad
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <PackageTags>parbad Payment Gateway virtual virtual-gateway Bank Iran Shetab IranKish Mellat Melli Sadad Parsian Pasargad Saman Asan-Pardakht پرداخت درگاه بانک ایران شتاب ایران-کیش ملت ملی سداد پارسیان پاسارگاد سامان آسان-پرداخت</PackageTags>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-	<PackageReleaseNotes>https://github.com/Sina-Soltani/Parbad/releases/tag/v3.11.1</PackageReleaseNotes>
+	<PackageReleaseNotes>https://github.com/Sina-Soltani/Parbad/releases/tag/v3.12.0</PackageReleaseNotes>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Parbad/tests/CallbackUrlTests.cs
+++ b/src/Parbad/tests/CallbackUrlTests.cs
@@ -57,6 +57,13 @@ public class CallbackUrlTests
     [TestMethod]
     public void NonValidUrl_Must_Throw_Exception()
     {
-        Assert.ThrowsException<CallbackUrlFormatException>(() => new CallbackUrl("abcd"));
+        try
+        {
+            _ = new CallbackUrl("abcd");
+            Assert.Fail("Expected CallbackUrlFormatException.");
+        }
+        catch (CallbackUrlFormatException)
+        {
+        }
     }
 }

--- a/src/Parbad/tests/Gateway/Melli/MelliCommonTests.cs
+++ b/src/Parbad/tests/Gateway/Melli/MelliCommonTests.cs
@@ -41,10 +41,14 @@ namespace Parbad.Tests.Gateway.Melli
 
             const string data = "test";
 
-            Assert.ThrowsException<MelliGatewayDataSigningException>(() =>
+            try
             {
                 crypto.Encrypt("test", data);
-            });
+                Assert.Fail("Expected MelliGatewayDataSigningException.");
+            }
+            catch (MelliGatewayDataSigningException)
+            {
+            }
         }
     }
 }

--- a/src/Parbad/tests/GatewayTransporterTests.cs
+++ b/src/Parbad/tests/GatewayTransporterTests.cs
@@ -1,6 +1,8 @@
-﻿using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Net.Http.Headers;
 using Parbad.Internal;
+using Parbad.Options;
 using Parbad.Tests.Helpers;
 using System.Collections.Generic;
 using System.Net;
@@ -13,6 +15,7 @@ namespace Parbad.Tests
     public class GatewayTransporterTests
     {
         private HttpContext _httpContext;
+        private ServiceProvider _services;
 
         [TestInitialize]
         public void Setup()
@@ -20,6 +23,16 @@ namespace Parbad.Tests
             var httpContextAccessor = MockHelpers.MockHttpContextAccessor();
 
             _httpContext = httpContextAccessor.HttpContext;
+            _services = new ServiceCollection()
+                        .Configure<ParbadOptions>(_ => { })
+                        .BuildServiceProvider();
+            _httpContext.RequestServices = _services;
+        }
+
+        [TestCleanup]
+        public Task Cleanup()
+        {
+            return _services.DisposeAsync().AsTask();
         }
 
         [TestMethod]
@@ -34,8 +47,8 @@ namespace Parbad.Tests
             await transporter.TransportAsync();
 
             Assert.AreEqual((int)HttpStatusCode.Redirect, _httpContext.Response.StatusCode);
-            Assert.IsNotNull(_httpContext.Response.Headers[HeaderNames.Location]);
-            Assert.AreEqual(expectedUrl, _httpContext.Response.Headers[HeaderNames.Location]);
+            Assert.IsFalse(string.IsNullOrEmpty(_httpContext.Response.Headers[HeaderNames.Location].ToString()));
+            Assert.AreEqual(expectedUrl, _httpContext.Response.Headers[HeaderNames.Location].ToString());
         }
 
         [TestMethod]

--- a/src/Parbad/tests/InvoiceBuilderTests.cs
+++ b/src/Parbad/tests/InvoiceBuilderTests.cs
@@ -23,9 +23,9 @@ namespace Parbad.Tests
         }
 
         [TestCleanup]
-        public ValueTask Cleanup()
+        public Task Cleanup()
         {
-            return _services.DisposeAsync();
+            return _services.DisposeAsync().AsTask();
         }
 
         [TestMethod]
@@ -100,14 +100,21 @@ namespace Parbad.Tests
         }
 
         [TestMethod]
-        public void Invoice_Must_Throw_Exception_When_Duplicate_AdditionalKey_Is_Added()
+        public async Task Invoice_Must_Throw_Exception_When_Duplicate_AdditionalKey_Is_Added()
         {
             const string key = "key";
 
             _builder.AddProperty(key, "");
             _builder.AddProperty(key, "");
 
-            Assert.ThrowsExceptionAsync<ArgumentException>(() => _builder.BuildAsync());
+            try
+            {
+                await _builder.BuildAsync();
+                Assert.Fail("Expected ArgumentException.");
+            }
+            catch (ArgumentException)
+            {
+            }
         }
 
         [TestMethod]

--- a/src/Parbad/tests/MoneyTests.cs
+++ b/src/Parbad/tests/MoneyTests.cs
@@ -57,8 +57,8 @@ namespace Parbad.Tests
         {
             var money = new Money(10);
 
-            Assert.AreEqual(money, 10L);
-            Assert.AreEqual(money, 10M);
+            Assert.AreEqual(10L, (long)money);
+            Assert.AreEqual(10M, (decimal)money);
             Assert.AreEqual(money, new Money(10));
         }
     }

--- a/src/Parbad/tests/Parbad.Tests.csproj
+++ b/src/Parbad/tests/Parbad.Tests.csproj
@@ -1,10 +1,20 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+    <PackageReference Include="MSTest.TestAdapter" Version="4.2.3" />
+    <PackageReference Include="MSTest.TestFramework" Version="4.2.3" />
+    <PackageReference Include="coverlet.collector" Version="10.0.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\..\tests\Parbad.Tests.Helpers\Parbad.Tests.Helpers.csproj" />

--- a/tests/Parbad.FrameworkCompatibility.Tests/FrameworkCompatibilityTests.cs
+++ b/tests/Parbad.FrameworkCompatibility.Tests/FrameworkCompatibilityTests.cs
@@ -1,0 +1,118 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Parbad.FrameworkCompatibility.Tests;
+
+[TestClass]
+public class FrameworkCompatibilityTests
+{
+    private static readonly string[] ExpectedRuntimeTargets =
+    [
+        "netcoreapp3.0",
+        "netcoreapp3.1",
+        "net5.0",
+        "net6.0",
+        "net7.0",
+        "net8.0",
+        "net9.0",
+        "net10.0"
+    ];
+
+    [TestMethod]
+    public void Current_runtime_target_is_declared_as_supported()
+    {
+        CollectionAssert.Contains(ExpectedRuntimeTargets, CurrentTargetFramework);
+    }
+
+    [TestMethod]
+    public void Runtime_compatible_project_assemblies_can_be_loaded()
+    {
+        var loadedAssemblies = GetCoveredProjectTypes()
+                               .Select(type => type.Assembly.GetName().Name)
+                               .Distinct()
+                               .OrderBy(name => name)
+                               .ToArray();
+
+        CollectionAssert.AreEquivalent(GetExpectedProjectAssemblyNames(), loadedAssemblies);
+    }
+
+    private static Type[] GetCoveredProjectTypes()
+    {
+        var types = new List<Type>
+        {
+            typeof(Parbad.Options.ParbadOptions),
+            typeof(Parbad.AspNetCore.VirtualGateway.ParbadVirtualGatewayMiddleware),
+            typeof(Parbad.Storage.Abstractions.IStorage),
+            typeof(Parbad.Storage.Cache.MemoryCache.MemoryCacheStorageOptions),
+            typeof(Parbad.Gateway.FanAva.FanAvaGatewayOptions),
+            typeof(Parbad.Gateway.IdPay.IdPayGatewayOptions),
+            typeof(Parbad.Gateway.IranKish.IranKishGatewayOptions),
+            typeof(Parbad.Gateway.PayIr.PayIrGatewayOptions),
+            typeof(Parbad.Gateway.PayPing.PayPingGatewayOptions),
+            typeof(Parbad.Gateway.Sepehr.SepehrGatewayOptions),
+            typeof(Parbad.Gateway.YekPay.YekPayGatewayOptions),
+            typeof(Parbad.Gateway.ZarinPal.ZarinPalGatewayOptions),
+            typeof(Parbad.Gateway.Zibal.ZibalGatewayOptions)
+        };
+
+#if NET5_0_OR_GREATER
+        types.Add(typeof(Parbad.Storage.EntityFrameworkCore.EntityFrameworkCoreStorage));
+#endif
+
+        return types.ToArray();
+    }
+
+    private static string[] GetExpectedProjectAssemblyNames()
+    {
+        var names = new List<string>
+        {
+            "Parbad",
+            "Parbad.AspNetCore",
+            "Parbad.Storage.Abstractions",
+            "Parbad.Storage.Cache",
+            "Parbad.Gateway.FanAva",
+            "Parbad.Gateway.IdPay",
+            "Parbad.Gateway.IranKish",
+            "Parbad.Gateway.PayIr",
+            "Parbad.Gateway.PayPing",
+            "Parbad.Gateway.Sepehr",
+            "Parbad.Gateway.YekPay",
+            "Parbad.Gateway.ZarinPal",
+            "Parbad.Gateway.Zibal"
+        };
+
+#if NET5_0_OR_GREATER
+        names.Add("Parbad.Storage.EntityFrameworkCore");
+#endif
+
+        return names.OrderBy(name => name).ToArray();
+    }
+
+    private static string CurrentTargetFramework
+    {
+        get
+        {
+#if NETCOREAPP3_0
+            return "netcoreapp3.0";
+#elif NETCOREAPP3_1
+            return "netcoreapp3.1";
+#elif NET5_0
+            return "net5.0";
+#elif NET6_0
+            return "net6.0";
+#elif NET7_0
+            return "net7.0";
+#elif NET8_0
+            return "net8.0";
+#elif NET9_0
+            return "net9.0";
+#elif NET10_0
+            return "net10.0";
+#else
+            return "unknown";
+#endif
+        }
+    }
+}

--- a/tests/Parbad.FrameworkCompatibility.Tests/Parbad.FrameworkCompatibility.Tests.csproj
+++ b/tests/Parbad.FrameworkCompatibility.Tests/Parbad.FrameworkCompatibility.Tests.csproj
@@ -1,0 +1,60 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>netcoreapp3.0;netcoreapp3.1;net5.0;net6.0;net7.0;net8.0;net9.0;net10.0</TargetFrameworks>
+    <LangVersion>latest</LangVersion>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.0' ">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' or '$(TargetFramework)' == 'net5.0' or '$(TargetFramework)' == 'net6.0' or '$(TargetFramework)' == 'net7.0' ">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' or '$(TargetFramework)' == 'net9.0' or '$(TargetFramework)' == 'net10.0' ">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+    <PackageReference Include="MSTest.TestAdapter" Version="4.2.3" />
+    <PackageReference Include="MSTest.TestFramework" Version="4.2.3" />
+    <PackageReference Include="coverlet.collector" Version="10.0.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Parbad\src\Parbad.csproj" />
+    <ProjectReference Include="..\..\src\Parbad.AspNetCore\src\Parbad.AspNetCore.csproj" />
+    <ProjectReference Include="..\..\src\Parbad.Storage\Abstractions\Parbad.Storage.Abstractions.csproj" />
+    <ProjectReference Include="..\..\src\Parbad.Storage\Cache\src\Parbad.Storage.Cache.csproj" />
+    <ProjectReference Include="..\..\src\Parbad.Gateway\FanAva\src\Parbad.Gateway.FanAva.csproj" />
+    <ProjectReference Include="..\..\src\Parbad.Gateway\IdPay\src\Parbad.Gateway.IdPay.csproj" />
+    <ProjectReference Include="..\..\src\Parbad.Gateway\IranKish\src\Parbad.Gateway.IranKish.csproj" />
+    <ProjectReference Include="..\..\src\Parbad.Gateway\PayIr\src\Parbad.Gateway.PayIr.csproj" />
+    <ProjectReference Include="..\..\src\Parbad.Gateway\PayPing\src\Parbad.Gateway.PayPing.csproj" />
+    <ProjectReference Include="..\..\src\Parbad.Gateway\Sepehr\src\Parbad.Gateway.Sepehr.csproj" />
+    <ProjectReference Include="..\..\src\Parbad.Gateway\YekPay\src\Parbad.Gateway.YekPay.csproj" />
+    <ProjectReference Include="..\..\src\Parbad.Gateway\ZarinPal\src\Parbad.Gateway.ZarinPal.csproj" />
+    <ProjectReference Include="..\..\src\Parbad.Gateway\Zibal\src\Parbad.Gateway.Zibal.csproj" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net5.0' or '$(TargetFramework)' == 'net6.0' or '$(TargetFramework)' == 'net7.0' or '$(TargetFramework)' == 'net8.0' or '$(TargetFramework)' == 'net9.0' or '$(TargetFramework)' == 'net10.0' ">
+    <ProjectReference Include="..\..\src\Parbad.Storage\EntityFrameworkCore\src\Parbad.Storage.EntityFrameworkCore.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Parbad.Tests.Helpers/GatewayOnResultHelper.cs
+++ b/tests/Parbad.Tests.Helpers/GatewayOnResultHelper.cs
@@ -78,7 +78,7 @@ namespace Parbad.Tests.Helpers
 
             Assert.AreEqual(GatewayAccount.DefaultName, result.GatewayAccountName);
 
-            Assert.AreEqual(result.Amount, expectedAmount);
+            Assert.AreEqual(expectedAmount, (decimal)result.Amount);
 
             Assert.IsFalse(result.IsAlreadyVerified);
         }
@@ -102,7 +102,7 @@ namespace Parbad.Tests.Helpers
 
             Assert.AreEqual(GatewayAccount.DefaultName, result.GatewayAccountName);
 
-            Assert.AreEqual(result.Amount, expectedAmount);
+            Assert.AreEqual(expectedAmount, (decimal)result.Amount);
 
             Assert.IsNotNull(result.TransactionCode);
 

--- a/tests/Parbad.Tests.Helpers/GatewayTestHelpers.cs
+++ b/tests/Parbad.Tests.Helpers/GatewayTestHelpers.cs
@@ -52,7 +52,7 @@ namespace Parbad.Tests.Helpers
 
             onRequestResult(requestResult);
 
-            var storageManager = serviceProvider.GetRequiredService<IStorageManager>();
+            var storageManager = serviceProvider.GetRequiredService<IStorage>();
 
             var payment = await storageManager.GetPaymentByTrackingNumberAsync(requestResult.TrackingNumber);
 

--- a/tests/Parbad.Tests.Helpers/Parbad.Tests.Helpers.csproj
+++ b/tests/Parbad.Tests.Helpers/Parbad.Tests.Helpers.csproj
@@ -1,32 +1,18 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0;net7.0;net8.0;net9.0;net10.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Moq" Version="4.15.1" />
-    <PackageReference Include="RichardSzalay.MockHttp" Version="6.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
-    <PackageReference Include="coverlet.collector" Version="3.2.0">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="RichardSzalay.MockHttp" Version="7.0.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="4.2.3" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' or '$(TargetFramework)' == 'netstandard2.1' ">
-    <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.2.0" />
-    <PackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="2.2.0" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.0' or '$(TargetFramework)' == 'netcoreapp3.1' or '$(TargetFramework)' == 'net5.0' or '$(TargetFramework)' == 'net6.0' or '$(TargetFramework)' == 'net7.0' or '$(TargetFramework)' == 'net8.0' or '$(TargetFramework)' == 'net9.0' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.0' or '$(TargetFramework)' == 'netcoreapp3.1' or '$(TargetFramework)' == 'net5.0' or '$(TargetFramework)' == 'net6.0' or '$(TargetFramework)' == 'net7.0' or '$(TargetFramework)' == 'net8.0' or '$(TargetFramework)' == 'net9.0' or '$(TargetFramework)' == 'net10.0' ">
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 


### PR DESCRIPTION
## Summary

This pull request adds .NET 10 support across the Parbad solution and prepares the packages for the v3.12.0 release.

It updates target frameworks, package references, release metadata, and test projects while preserving compatibility with existing legacy targets. It also adds a dedicated multi-targeted framework compatibility test project to make sure Parbad remains buildable and loadable across the supported .NET runtime matrix.

## What changed

### .NET 10 support

- Added `net10.0` target framework support across:
  - Parbad core
  - ASP.NET Core integration
  - MVC / OWIN packages
  - Storage packages
  - Gateway packages
  - Test projects

### Package reference updates

- Updated package references where compatible with the existing target framework matrix.
- Kept legacy `netstandard2.0` / `netstandard2.1` dependency groups on compatible ASP.NET Core and Microsoft.Extensions package lines to avoid breaking older consumers.
- Added conditional Entity Framework Core references:
  - Legacy EF Core storage targets continue using the latest compatible EF Core 5.x line.
  - `net10.0` targets use EF Core 10.
- Added direct compatibility/security package overrides for vulnerable transitive dependencies without forcing legacy targets onto modern-only dependency versions.

### Test updates

- Updated test package references.
- Made previously non-discoverable gateway/core tests executable.
- Adjusted tests for MSTest 4 behavior and .NET 10 runtime expectations.
- Fixed .NET 10 build issues in cache and Entity Framework Core storage tests.
- Replaced obsolete test-helper storage usage where needed.

### ASP.NET Core compatibility

- Updated the virtual gateway middleware environment handling for modern ASP.NET Core targets by using `IWebHostEnvironment` where appropriate, while keeping compatibility with older hosting abstractions.

### Release metadata

- Bumped package versions for the v3.12.0 release.
- Updated `<PackageReleaseNotes>` links in project files to point to the v3.12.0 release notes.
- These release metadata changes do not introduce functional behavior changes by themselves.

### Cross-framework compatibility tests

- Added a new multi-targeted test project:

  `tests/Parbad.FrameworkCompatibility.Tests`

- The new test project targets the supported runtime matrix from `netcoreapp3.0` through `net10.0`.
- It verifies that:
  - The current executing target framework is part of the expected supported runtime list.
  - Runtime-compatible Parbad assemblies can be loaded successfully for each target.
- Entity Framework Core storage compatibility checks are included only for `net5.0` and later, because that package does not target `netcoreapp3.x`.
- Added the new compatibility test project to `Parbad.sln` so it runs as part of the full solution test suite.

## Why

.NET 10 support requires updating target frameworks, package references, test dependencies, and a few compatibility-specific code paths.

The new compatibility test project provides a regression safety net for future framework/package updates, ensuring the declared Parbad runtime support matrix remains buildable and testable.

## Validation

The changes were validated with:

```bash
dotnet restore Parbad.sln
dotnet build
dotnet test
dotnet test Parbad.sln --no-build --no-restore
dotnet build tests/Parbad.FrameworkCompatibility.Tests/Parbad.FrameworkCompatibility.Tests.csproj --no-restore -v:q
dotnet test tests/Parbad.FrameworkCompatibility.Tests/Parbad.FrameworkCompatibility.Tests.csproj --no-build --no-restore